### PR TITLE
Stockfish vs. Stockfish game

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,6 +700,8 @@ dependencies = [
 [[package]]
 name = "bevy_local_commands"
 version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9f3d7a994cc7cad3f3b14af69dfca8cf46414791072090561c05a55f173e73"
 dependencies = [
  "bevy",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06"
 dependencies = [
  "async-lock 2.8.0",
- "autocfg",
+ "autocfg 1.1.0",
  "blocking",
  "futures-lite 1.13.0",
 ]
@@ -296,6 +296,15 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
+dependencies = [
+ "autocfg 1.1.0",
+]
 
 [[package]]
 name = "autocfg"
@@ -1267,6 +1276,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1448,6 +1466,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1487,6 +1524,12 @@ name = "downcast-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
+
+[[package]]
+name = "either"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "encase"
@@ -1601,6 +1644,7 @@ version = "0.1.0"
 dependencies = [
  "bevy",
  "bevy_local_commands",
+ "pleco",
 ]
 
 [[package]]
@@ -1666,6 +1710,12 @@ name = "foreign-types-shared"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures-core"
@@ -1936,6 +1986,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
 name = "hexasphere"
 version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1971,7 +2027,7 @@ version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "hashbrown 0.12.3",
 ]
 
@@ -2187,7 +2243,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "scopeguard",
 ]
 
@@ -2272,6 +2328,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "mucow"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c55d0c9dc43dedfd2414deb74ade67687749ef88b1d3482024d4c81d901a7a83"
 
 [[package]]
 name = "naga"
@@ -2417,7 +2479,7 @@ version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-traits",
 ]
 
@@ -2427,7 +2489,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-integer",
  "num-traits",
 ]
@@ -2438,7 +2500,17 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -2680,6 +2752,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
 
 [[package]]
+name = "pleco"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a8c8ab569c544644c468a63f4fe4b33c0706b1472bebb517fabb75ec0f688e"
+dependencies = [
+ "bitflags 1.3.2",
+ "lazy_static",
+ "mucow",
+ "num_cpus",
+ "rand",
+ "rayon",
+]
+
+[[package]]
 name = "png"
 version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2742,6 +2828,112 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17fd96390ed3feda12e1dfe2645ed587e0bea749e319333f104a33ff62f77a0b"
 
 [[package]]
+name = "rand"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+dependencies = [
+ "autocfg 0.1.8",
+ "libc",
+ "rand_chacha",
+ "rand_core 0.4.2",
+ "rand_hc",
+ "rand_isaac",
+ "rand_jitter",
+ "rand_os",
+ "rand_pcg",
+ "rand_xorshift",
+ "winapi",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+dependencies = [
+ "autocfg 0.1.8",
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
+dependencies = [
+ "libc",
+ "rand_core 0.4.2",
+ "winapi",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+dependencies = [
+ "cloudabi",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.4.2",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+dependencies = [
+ "autocfg 0.1.8",
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
 name = "range-alloc"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2752,6 +2944,35 @@ name = "raw-window-handle"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
+
+[[package]]
+name = "rayon"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
+]
 
 [[package]]
 name = "rectangle-pack"
@@ -2957,7 +3178,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "AGPL-3.0-or-later"
 
 [dependencies]
 bevy = "0.12"
-bevy_local_commands = { path = "../../bevyengine/bevy_local_commands" }
+bevy_local_commands = "0.4.0"
 pleco = "0.5.0"
 
 # Enable high optimizations for dependencies (incl. Bevy), but not for our code:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "AGPL-3.0-or-later"
 [dependencies]
 bevy = "0.12"
 bevy_local_commands = { path = "../../bevyengine/bevy_local_commands" }
+pleco = "0.5.0"
 
 # Enable high optimizations for dependencies (incl. Bevy), but not for our code:
 [profile.dev.package."*"]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -56,7 +56,7 @@ fn handle_engine_uci_init(
     mut state_query: Query<&mut EngineState>,
 ) {
     for output in output_event.read() {
-        for line in &output.output {
+        for line in output.lines() {
             if line.trim().starts_with("uciok") {
                 if let Ok(mut state) = state_query.get_mut(output.entity) {
                     println!("Engine ready!");

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,7 +1,7 @@
 use bevy::prelude::*;
 use bevy_local_commands::{LocalCommand, Process, ProcessOutput};
 
-use crate::{process_log::LogSet, GameRef};
+use crate::{game::GameRef, process_log::LogSet};
 
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Component)]
 enum EngineState {
@@ -13,7 +13,7 @@ enum EngineState {
 
 #[derive(Debug, Component, Event)]
 pub struct StartEngine {
-    pub game_id: Entity,
+    pub game_ref: GameRef,
     pub path: String,
 }
 
@@ -37,7 +37,7 @@ fn handle_start_engine(mut start_engine_event: EventReader<StartEngine>, mut com
     for start_engine in start_engine_event.read() {
         commands.spawn((
             EngineState::default(),
-            GameRef(start_engine.game_id),
+            start_engine.game_ref,
             LocalCommand::new(start_engine.path.clone()),
         ));
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -27,15 +27,17 @@ pub struct EnginePlugin;
 
 impl Plugin for EnginePlugin {
     fn build(&self, app: &mut App) {
-        app.add_event::<StartEngine>().add_systems(
-            Update,
-            (
-                handle_start_engine,
-                handle_engine_startup,
-                handle_engine_uci_init,
-            )
-                .after(LogSet),
-        );
+        app.add_event::<StartEngine>()
+            .add_event::<EngineInitialized>()
+            .add_systems(
+                Update,
+                (
+                    handle_start_engine,
+                    handle_engine_startup,
+                    handle_engine_uci_init,
+                )
+                    .after(LogSet),
+            );
     }
 }
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -28,7 +28,7 @@ pub struct GamePlugin;
 
 impl Plugin for GamePlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(
+        app.add_event::<CreateGame>().add_systems(
             Update,
             (
                 handle_game_creation,

--- a/src/game.rs
+++ b/src/game.rs
@@ -1,0 +1,53 @@
+use bevy::prelude::*;
+use pleco::{Board, Player};
+
+use crate::engine::StartEngine;
+
+#[derive(Debug, Default, Component)]
+pub struct Game;
+
+#[derive(Debug, Component, Clone, Copy)]
+pub struct GameRef {
+    pub game_id: Entity,
+    pub player: Player,
+}
+
+#[derive(Debug, Default, Component, Deref, DerefMut)]
+pub struct GameBoard(Board);
+
+#[derive(Debug, Event)]
+pub struct CreateGame;
+
+pub struct GamePlugin;
+
+impl Plugin for GamePlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Update, handle_game_creation);
+    }
+}
+
+fn handle_game_creation(
+    mut create_game_event: EventReader<CreateGame>,
+    mut commands: Commands,
+    mut start_engine_event: EventWriter<StartEngine>,
+) {
+    for _ in create_game_event.read() {
+        let game_id = commands.spawn((Game, GameBoard::default())).id();
+
+        // Add players
+        start_engine_event.send(StartEngine {
+            game_ref: GameRef {
+                game_id,
+                player: Player::White,
+            },
+            path: "stockfish".to_string(),
+        });
+        start_engine_event.send(StartEngine {
+            game_ref: GameRef {
+                game_id,
+                player: Player::Black,
+            },
+            path: "stockfish".to_string(),
+        });
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,17 +2,13 @@ use std::time::Duration;
 
 use bevy::{app::ScheduleRunnerPlugin, prelude::*};
 use bevy_local_commands::BevyLocalCommandsPlugin;
-use engine::{EnginePlugin, StartEngine};
+use engine::EnginePlugin;
+use game::CreateGame;
 use process_log::ProcessLogPlugin;
 
 mod engine;
+mod game;
 mod process_log;
-
-#[derive(Debug, Default, Component)]
-struct Game;
-
-#[derive(Debug, Component)]
-struct GameRef(Entity);
 
 fn main() {
     App::new()
@@ -25,14 +21,10 @@ fn main() {
             ProcessLogPlugin,
             EnginePlugin,
         ))
-        .add_systems(Startup, start_stockfish)
+        .add_systems(Startup, create_game)
         .run();
 }
 
-fn start_stockfish(mut commands: Commands, mut start_engine_event: EventWriter<StartEngine>) {
-    let game_id = commands.spawn(Game).id();
-    start_engine_event.send(StartEngine {
-        game_id,
-        path: "stockfish".to_string(),
-    });
+fn create_game(mut create_game_event: EventWriter<CreateGame>) {
+    create_game_event.send(CreateGame);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use bevy::{app::ScheduleRunnerPlugin, prelude::*};
 use bevy_local_commands::BevyLocalCommandsPlugin;
 use engine::EnginePlugin;
-use game::CreateGame;
+use game::{CreateGame, GamePlugin};
 use process_log::ProcessLogPlugin;
 
 mod engine;
@@ -20,6 +20,7 @@ fn main() {
             BevyLocalCommandsPlugin,
             ProcessLogPlugin,
             EnginePlugin,
+            GamePlugin,
         ))
         .add_systems(Startup, create_game)
         .run();

--- a/src/process_log.rs
+++ b/src/process_log.rs
@@ -14,7 +14,7 @@ impl Plugin for ProcessLogPlugin {
 
 fn log_output(mut output_event: EventReader<ProcessOutput>) {
     for output in output_event.read() {
-        println!("{}", output.output.join("\n"));
+        println!("{}", output.all());
     }
 }
 


### PR DESCRIPTION
# Objective

Closes #15, closes #16.

As a first prototype, fishpond should be able to simulate a game of Stockfish vs. Stockfish.

# Solution

Two Stockfish processes are spawned and sent UCI commands to play against each other.
The move time is currently fixed at 200 ms for easy debugging.
Each move is logged and checkmate is recognized to end the game.

The `pleco` crate is used for tracking the game state and validating the moves.