### PR TITLE
Migrate from `pleco` to `shakmaty`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06"
 dependencies = [
  "async-lock 2.8.0",
- "autocfg 1.1.0",
+ "autocfg",
  "blocking",
  "futures-lite 1.13.0",
 ]
@@ -296,15 +296,6 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "autocfg"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
-dependencies = [
- "autocfg 1.1.0",
-]
 
 [[package]]
 name = "autocfg"
@@ -1192,6 +1183,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "btoi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd6407f73a9b8b6162d8a2ef999fe6afd7cc15902ebf42c5cd296addf17e0ad"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1275,15 +1275,6 @@ dependencies = [
  "glob",
  "libc",
  "libloading 0.8.1",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1468,25 +1459,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1526,12 +1498,6 @@ name = "downcast-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
-
-[[package]]
-name = "either"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "encase"
@@ -1646,7 +1612,7 @@ version = "0.1.0"
 dependencies = [
  "bevy",
  "bevy_local_commands",
- "pleco",
+ "shakmaty",
 ]
 
 [[package]]
@@ -1712,12 +1678,6 @@ name = "foreign-types-shared"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures-core"
@@ -1988,12 +1948,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
-
-[[package]]
 name = "hexasphere"
 version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2029,7 +1983,7 @@ version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "hashbrown 0.12.3",
 ]
 
@@ -2245,7 +2199,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "scopeguard",
 ]
 
@@ -2330,12 +2284,6 @@ dependencies = [
  "wasi",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "mucow"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55d0c9dc43dedfd2414deb74ade67687749ef88b1d3482024d4c81d901a7a83"
 
 [[package]]
 name = "naga"
@@ -2481,7 +2429,7 @@ version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "num-traits",
 ]
 
@@ -2491,7 +2439,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -2502,17 +2450,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
- "autocfg 1.1.0",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
+ "autocfg",
 ]
 
 [[package]]
@@ -2754,20 +2692,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
 
 [[package]]
-name = "pleco"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a8c8ab569c544644c468a63f4fe4b33c0706b1472bebb517fabb75ec0f688e"
-dependencies = [
- "bitflags 1.3.2",
- "lazy_static",
- "mucow",
- "num_cpus",
- "rand",
- "rayon",
-]
-
-[[package]]
 name = "png"
 version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2830,112 +2754,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17fd96390ed3feda12e1dfe2645ed587e0bea749e319333f104a33ff62f77a0b"
 
 [[package]]
-name = "rand"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
-dependencies = [
- "autocfg 0.1.8",
- "libc",
- "rand_chacha",
- "rand_core 0.4.2",
- "rand_hc",
- "rand_isaac",
- "rand_jitter",
- "rand_os",
- "rand_pcg",
- "rand_xorshift",
- "winapi",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
-dependencies = [
- "autocfg 0.1.8",
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
-name = "rand_hc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_isaac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_jitter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
-dependencies = [
- "libc",
- "rand_core 0.4.2",
- "winapi",
-]
-
-[[package]]
-name = "rand_os"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.4.2",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
-dependencies = [
- "autocfg 0.1.8",
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
 name = "range-alloc"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2946,35 +2764,6 @@ name = "raw-window-handle"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
-
-[[package]]
-name = "rayon"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
-]
 
 [[package]]
 name = "rectangle-pack"
@@ -3154,6 +2943,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "shakmaty"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da274d26b6aac011b0af8ec3514eb1d598cf51fb47944d1d2142338f210cfb3"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.4.1",
+ "btoi",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3180,7 +2980,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "AGPL-3.0-or-later"
 [dependencies]
 bevy = "0.12"
 bevy_local_commands = "0.4.0"
-pleco = "0.5.0"
+shakmaty = "0.26.0"
 
 # Enable high optimizations for dependencies (incl. Bevy), but not for our code:
 [profile.dev.package."*"]

--- a/src/game.rs
+++ b/src/game.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use pleco::{Board, Player};
+use shakmaty::{fen::Fen, Chess, Color, Move, Outcome, Position};
 
 use crate::engine::{EngineInitialized, SearchMove, SearchResult, StartEngine};
 
@@ -9,18 +9,80 @@ pub struct Game;
 #[derive(Debug, Component, Clone, Copy, PartialEq)]
 pub struct GameRef {
     pub game_id: Entity,
-    pub player: Player,
+    pub player: Color,
 }
 
 #[derive(Debug, Component)]
 pub enum GameState {
     PlayerInitialization { white: bool, black: bool },
-    WaitingForPlayer { player: Player },
+    WaitingForPlayer { player: Color },
     Finished,
 }
 
 #[derive(Debug, Default, Component, Deref, DerefMut, Clone)]
-pub struct GameBoard(Board);
+pub struct GameBoard(Chess);
+
+impl Position for GameBoard {
+    fn board(&self) -> &shakmaty::Board {
+        self.0.board()
+    }
+
+    fn promoted(&self) -> shakmaty::Bitboard {
+        self.0.promoted()
+    }
+
+    fn pockets(&self) -> Option<&shakmaty::ByColor<shakmaty::ByRole<u8>>> {
+        self.0.pockets()
+    }
+
+    fn turn(&self) -> Color {
+        self.0.turn()
+    }
+
+    fn castles(&self) -> &shakmaty::Castles {
+        self.0.castles()
+    }
+
+    fn maybe_ep_square(&self) -> Option<shakmaty::Square> {
+        self.0.maybe_ep_square()
+    }
+
+    fn remaining_checks(&self) -> Option<&shakmaty::ByColor<shakmaty::RemainingChecks>> {
+        self.0.remaining_checks()
+    }
+
+    fn halfmoves(&self) -> u32 {
+        self.0.halfmoves()
+    }
+
+    fn fullmoves(&self) -> std::num::NonZeroU32 {
+        self.0.fullmoves()
+    }
+
+    fn into_setup(self, mode: shakmaty::EnPassantMode) -> shakmaty::Setup {
+        self.0.into_setup(mode)
+    }
+
+    fn legal_moves(&self) -> shakmaty::MoveList {
+        self.0.legal_moves()
+    }
+
+    fn is_variant_end(&self) -> bool {
+        self.0.is_variant_end()
+    }
+
+    fn has_insufficient_material(&self, color: Color) -> bool {
+        self.0.has_insufficient_material(color)
+    }
+
+    fn variant_outcome(&self) -> Option<Outcome> {
+        self.0.variant_outcome()
+    }
+
+    fn play_unchecked(&mut self, m: &Move) {
+        self.0.play_unchecked(m)
+    }
+}
 
 #[derive(Debug, Event)]
 pub struct CreateGame;
@@ -61,14 +123,14 @@ fn handle_game_creation(
         start_engine_event.send(StartEngine {
             game_ref: GameRef {
                 game_id,
-                player: Player::White,
+                player: Color::White,
             },
             path: "stockfish".to_string(),
         });
         start_engine_event.send(StartEngine {
             game_ref: GameRef {
                 game_id,
-                player: Player::Black,
+                player: Color::Black,
             },
             path: "stockfish".to_string(),
         });
@@ -85,19 +147,19 @@ fn handle_engine_startup_engine_initialization(
             game_query.get_mut(engine_initialized.game_ref.game_id)
         {
             if let GameState::PlayerInitialization { white, black } = *game_state {
-                let new_white = white || engine_initialized.game_ref.player == Player::White;
-                let new_black = black || engine_initialized.game_ref.player == Player::Black;
+                let new_white = white || engine_initialized.game_ref.player == Color::White;
+                let new_black = black || engine_initialized.game_ref.player == Color::Black;
 
                 if new_white && new_black {
                     *game_state = GameState::WaitingForPlayer {
-                        player: Player::White,
+                        player: Color::White,
                     };
 
                     // White moves first
                     search_move_event.send(SearchMove {
                         game_ref: GameRef {
                             game_id,
-                            player: Player::White,
+                            player: Color::White,
                         },
                         game_board: game_board.clone(),
                     });
@@ -126,17 +188,27 @@ fn handle_engine_search_result(
                 continue;
             }
 
-            if !game_board.apply_uci_move(&search_result.uci_move) {
-                println!("Invalid UCI move {}", search_result.uci_move);
+            let Ok(r#move) = search_result.uci_move.to_move(&*game_board) else {
+                println!("Invalid UCI move");
                 continue;
-            }
+            };
 
-            println!("Played {} -> {}", search_result.uci_move, game_board.fen());
+            // Move is already validated when parsing UCI
+            game_board.play_unchecked(&r#move);
 
-            if game_board.checkmate() {
+            println!(
+                "Played {} -> {}",
+                search_result.uci_move,
+                Fen::from_position(game_board.clone(), shakmaty::EnPassantMode::Legal)
+            );
+
+            if let Some(outcome) = game_board.outcome() {
                 *game_state = GameState::Finished;
 
-                println!("Game over, {:?} won!", game_board.turn().other_player());
+                match outcome {
+                    Outcome::Decisive { winner } => println!("Game over, {winner} won!"),
+                    Outcome::Draw => println!("Game over with a draw!"),
+                };
             } else {
                 // Next player's turn
                 *game_state = GameState::WaitingForPlayer {


### PR DESCRIPTION
# Objective

Closes #25.

`shakmaty` offers better documentation, variant support and SAN notation.

# Solution

Migrate from `pleco` to `shakmaty`.