### PR TITLE
Add PGN export

### DIFF
--- a/crates/fishpond_game/src/lib.rs
+++ b/crates/fishpond_game/src/lib.rs
@@ -8,6 +8,8 @@ use shakmaty::{
     Color, Move, Position,
 };
 
+pub mod pgn;
+
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub enum DeclareDrawReason {
     /// The same position was repeated at least 3 times.

--- a/crates/fishpond_game/src/pgn.rs
+++ b/crates/fishpond_game/src/pgn.rs
@@ -4,11 +4,13 @@ use shakmaty::{san::San, Position};
 
 use crate::Game;
 
+/// Portable game notation (PGN) to record an entire chess game.
 pub struct Pgn<P: Position> {
     game: Game<P>,
 }
 
 impl<P: Position> Pgn<P> {
+    /// Create a portable game notation (PGN) for the given game.
     pub fn from_game(game: Game<P>) -> Self {
         Pgn { game }
     }

--- a/crates/fishpond_game/src/pgn.rs
+++ b/crates/fishpond_game/src/pgn.rs
@@ -1,0 +1,62 @@
+use std::fmt::Display;
+
+use shakmaty::{san::San, Position};
+
+use crate::Game;
+
+pub struct Pgn<P: Position> {
+    game: Game<P>,
+}
+
+impl<P: Position> Pgn<P> {
+    pub fn from_game(game: Game<P>) -> Self {
+        Pgn { game }
+    }
+}
+
+impl<P: Position + Clone> Display for Pgn<P> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Mandatory tags
+        // TODO: Provide means to fill these out properly
+        writeln!(f, "[Event \"?\"]")?;
+        writeln!(f, "[Site \"fishpond\"]")?;
+        writeln!(f, "[Date \"????.??.??\"]")?;
+        writeln!(f, "[Round \"?\"]")?;
+        writeln!(f, "[White \"?\"]")?;
+        writeln!(f, "[Black \"?\"]")?;
+
+        let result = match self.game.outcome() {
+            Some(shakmaty::Outcome::Draw) => "1/2-1/2",
+            Some(shakmaty::Outcome::Decisive { winner }) => match winner {
+                shakmaty::Color::White => "1-0",
+                shakmaty::Color::Black => "0-1",
+            },
+            None => "*",
+        };
+
+        writeln!(f, "[Result \"{result}\"]")?;
+        writeln!(f, "\n")?;
+
+        let mut current_position = self.game.start_position().clone();
+
+        for (index, r#move) in self.game.moves().enumerate() {
+            if index % 2 == 0 {
+                // Move number
+                write!(f, "{}.", index + 1)?;
+            }
+
+            // Move in SAN notation
+            write!(f, " {}", San::from_move(&current_position, r#move))?;
+
+            // Update position
+            // All moves in the game are expected to be validated already
+            current_position.play_unchecked(r#move);
+        }
+
+        if result != "*" {
+            write!(f, " {result}")?;
+        }
+
+        Ok(())
+    }
+}

--- a/crates/fishpond_game/src/pgn.rs
+++ b/crates/fishpond_game/src/pgn.rs
@@ -35,14 +35,18 @@ impl<P: Position + Clone> Display for Pgn<P> {
         };
 
         writeln!(f, "[Result \"{result}\"]")?;
-        writeln!(f, "\n")?;
+        writeln!(f)?;
 
         let mut current_position = self.game.start_position().clone();
 
         for (index, r#move) in self.game.moves().enumerate() {
             if index % 2 == 0 {
                 // Move number
-                write!(f, "{}.", index + 1)?;
+                if index > 0 {
+                    write!(f, " {}.", index + 1)?;
+                } else {
+                    write!(f, "{}.", index + 1)?;
+                }
             }
 
             // Move in SAN notation

--- a/src/chess.rs
+++ b/src/chess.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use fishpond_game::{DeclareDrawReason, Game, Outcome};
+use fishpond_game::{pgn::Pgn, DeclareDrawReason, Game, Outcome};
 use shakmaty::{fen::Fen, Chess, Color, Position};
 
 use crate::engine::{EngineInitialized, SearchMove, SearchResult, StartEngine};
@@ -168,12 +168,17 @@ fn handle_engine_search_result(
             if let Some(outcome) = game.game_outcome() {
                 *game_state = GameState::Finished;
 
+                // Log game in PGN notation
+                let pgn = Pgn::from_game(game.clone());
+                println!("\n{pgn}\n");
+
                 match outcome {
                     Outcome::Decisive { winner, reason } => {
                         println!("GAME OVER | {winner} WON due to {reason:?}!")
                     }
                     Outcome::Draw { reason } => println!("GAME OVER | DRAW due to {reason:?}"),
                 };
+
                 return;
             }
 


### PR DESCRIPTION
# Objective

Closes #23.

Since we don't have a UI yet, it's hard to follow the moves of the games.
As a temporary solution, we should log the PGN of a game at the end, to be able to import it in Lichess.
Later on, we will need PGN exports anyway.

# Solution

Add a struct to construct PGN from a `Game` to `fishpond_game`.
It's currently quite rudimentary and has placeholders for a lot of the values, e.g. player names.
But the move list is already given so that you can import it in Lichess.