### PR TITLE
Add tests for UCI command parsing/stringification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1613,6 +1613,7 @@ dependencies = [
  "bevy",
  "bevy_local_commands",
  "fishpond_game",
+ "rstest",
  "shakmaty",
 ]
 
@@ -1689,10 +1690,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -1726,6 +1763,53 @@ dependencies = [
  "futures-io",
  "parking",
  "pin-project-lite",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+
+[[package]]
+name = "futures-task"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
+name = "futures-util"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -2684,6 +2768,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "piper"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2849,6 +2939,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "relative-path"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
+
+[[package]]
 name = "renderdoc-sys"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2877,6 +2973,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97eeab2f3c0a199bc4be135c36c924b6590b88c377d416494288c14f2db30199"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d428f8247852f894ee1be110b375111b586d4fa431f6c46e64ba5a0dcccbe605"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.48",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2887,6 +3012,15 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "ruzstd"
@@ -2919,6 +3053,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ opt-level = 3
 [workspace]
 resolver = "2"
 members = ["crates/*"]
+
+[dev-dependencies]
+rstest = "0.18.2"

--- a/crates/fishpond_game/src/lib.rs
+++ b/crates/fishpond_game/src/lib.rs
@@ -5,7 +5,7 @@ use bevy_ecs::component::Component;
 use shakmaty::{
     fen::Fen,
     zobrist::{Zobrist128, ZobristHash},
-    Color, Move, Position,
+    Chess, Color, Move, Position,
 };
 
 pub mod pgn;
@@ -245,17 +245,27 @@ where
 
     /// The position with move history in UCI notation.
     pub fn uci_position_with_moves(&self) -> String {
-        let uci_start =
+        let start_fen =
             Fen::from_position(self.start_position.clone(), shakmaty::EnPassantMode::Legal);
+        // FEN of the standard starting position
+        let start_pos_fen = Fen::from_position(Chess::new(), shakmaty::EnPassantMode::Legal);
+
+        // Use "startpos" for standard starting position
+        let uci_start = if start_pos_fen == start_fen {
+            "startpos".to_string()
+        } else {
+            format!("fen {}", start_fen)
+        };
+
         let uci_moves: Vec<_> = self
             .moves()
             .map(|r#move| r#move.to_uci(shakmaty::CastlingMode::Standard).to_string())
             .collect();
 
         if uci_moves.is_empty() {
-            format!("fen {uci_start}")
+            uci_start
         } else {
-            format!("fen {uci_start} moves {}", uci_moves.join(" "))
+            format!("{uci_start} moves {}", uci_moves.join(" "))
         }
     }
 

--- a/src/engine/uci.rs
+++ b/src/engine/uci.rs
@@ -15,7 +15,7 @@ impl Display for UciParseError {
 impl Error for UciParseError {}
 
 /// A UCI command sent from the engine to the GUI.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum UciToGuiCmd {
     UciOk,
     Id {
@@ -94,5 +94,20 @@ impl Display for UciToEngineCmd {
             }
             Self::Go { move_time } => writeln!(f, "go movetime {}", move_time.as_millis()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("uciok", UciToGuiCmd::UciOk)]
+    #[case("id name Stockfish 16", UciToGuiCmd::Id { name: Some("Stockfish 16".to_string()), author: None })]
+    #[case("id author the Stockfish developers (see AUTHORS file)", UciToGuiCmd::Id { name: None, author: Some("the Stockfish developers (see AUTHORS file)".to_string()) })]
+    #[case("bestmove e2e4 ponder e7e5", UciToGuiCmd::BestMove { uci_move: Uci::from_str("e2e4").unwrap() })]
+    fn test_uci_to_gui_cmd_valid(#[case] input: &str, #[case] expected: UciToGuiCmd) {
+        assert_eq!(input.parse::<UciToGuiCmd>().unwrap(), expected);
     }
 }

--- a/src/engine/uci.rs
+++ b/src/engine/uci.rs
@@ -92,7 +92,7 @@ impl Display for UciToEngineCmd {
             Self::Position { game } => {
                 write!(f, "position {}", game.uci_position_with_moves())
             }
-            Self::Go { move_time } => writeln!(f, "go movetime {}", move_time.as_millis()),
+            Self::Go { move_time } => write!(f, "go movetime {}", move_time.as_millis()),
         }
     }
 }
@@ -101,6 +101,7 @@ impl Display for UciToEngineCmd {
 mod tests {
     use super::*;
     use rstest::rstest;
+    use shakmaty::Position;
 
     #[rstest]
     #[case("uciok", UciToGuiCmd::UciOk)]
@@ -109,5 +110,13 @@ mod tests {
     #[case("bestmove e2e4 ponder e7e5", UciToGuiCmd::BestMove { uci_move: Uci::from_str("e2e4").unwrap() })]
     fn test_uci_to_gui_cmd_valid(#[case] input: &str, #[case] expected: UciToGuiCmd) {
         assert_eq!(input.parse::<UciToGuiCmd>().unwrap(), expected);
+    }
+
+    #[rstest]
+    #[case(UciToEngineCmd::Uci, "uci")]
+    #[case(UciToEngineCmd::Position { game: Game::from_start_position(Chess::new()).into() }, "position startpos")]
+    #[case(UciToEngineCmd::Go { move_time: Duration::from_millis(1234) }, "go movetime 1234")]
+    fn test_uci_to_engine_cmd_display(#[case] input: UciToEngineCmd, #[case] expected: &str) {
+        assert_eq!(format!("{input}"), expected.to_string());
     }
 }

--- a/src/engine/uci.rs
+++ b/src/engine/uci.rs
@@ -101,7 +101,6 @@ impl Display for UciToEngineCmd {
 mod tests {
     use super::*;
     use rstest::rstest;
-    use shakmaty::Position;
 
     #[rstest]
     #[case("uciok", UciToGuiCmd::UciOk)]


### PR DESCRIPTION
# Objective

Closes #38.

In order to ensure that the engine and GUI can communicate without bugs, we should test that common commands are parsed / stringified correctly.

# Solution

- Add the `rstest` crate for parameterized tests.
- Add tests for parsing UCI commands to the GUI.
- Add tests for stringifying UCI commands to the engine.

The tests are not really comprehensive, but should serve as a good starting point.

Two bugs have been fixed while implementing the tests:

- The `go` command would send an extra newline character.
- The `position` command would not use `startpos` for the initial position.