### PR TITLE
Track engine search info

### DIFF
--- a/crates/fishpond_backend/src/engine/mod.rs
+++ b/crates/fishpond_backend/src/engine/mod.rs
@@ -135,6 +135,7 @@ fn handle_engine_to_gui(
                 }
                 println!("Updated engine ID to {id:?}");
             }
+            uci::UciToGuiCmd::Info(_) => todo!(),
             uci::UciToGuiCmd::BestMove { uci_move } => search_result_event.send(SearchResult {
                 game_ref: *game_ref,
                 uci_move: uci_move.clone(),


### PR DESCRIPTION
# Objective

Closes #32.

Engines continuously send the current search state with the UCI `info` command.
We should track this to be able to display hints in the GUI.

# Solution

- Implement UCI parsing of the `info` command.

# TODO

- Use the parsed UCI info command to update the search info.